### PR TITLE
💚(repo): fix handling of cypress in actions

### DIFF
--- a/.github/workflows/nxtest.yml
+++ b/.github/workflows/nxtest.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     name: Generate cache
     runs-on: ubuntu-latest
-    steps: 
+    steps:
         #Checking out to the develop branch
       - name: Checkout develop
         uses: actions/checkout@v2
@@ -57,15 +57,11 @@ jobs:
 
       - name: Cache Cypress Binary
         id: cache-cypress-binary
-        if: ${{ inputs.testtype == 'e2e'  }}
+        if: ${{ inputs.testtype == 'e2e' }}
         uses: actions/cache@v2
         with:
-          path: cypress/cache
+          path: ~/.cache/cypress
           key: cypress-binary-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Cypress Install
-        if: ${{ inputs.testtype == 'e2e'  }}
-        run: npm install cypress
 
       - name: Lint test affected
         if: ${{ inputs.testtype == 'lint' && inputs.test == 'affected' }}


### PR DESCRIPTION
the existing action used npm to install cypress despite
the fact that cypress is included as dev dependency in our
package.json already.

Additionally, according to https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml
the correct path to cache is ~/.cache/cypress